### PR TITLE
EmulatorPkg/WinHost: Add EFI_BUFFER_TOO_SMALL for return status.

### DIFF
--- a/EmulatorPkg/Win/Host/WinFileSystem.c
+++ b/EmulatorPkg/Win/Host/WinFileSystem.c
@@ -1159,6 +1159,12 @@ WinNtFileRead (
       }
     }
 
+    if (FileSize > *BufferSize) {
+      Status = EFI_BUFFER_TOO_SMALL;
+      *BufferSize = FileSize;
+      goto Done;
+    }
+
     Status = ReadFile (
       PrivateFile->LHandle,
       Buffer,


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2605

I think it is necessary that check the buffer size before ReadFile, it
will inform the caller that they should provide more buffer.

Cc: Jordan Justen <jordan.l.justen@intel.com>
Cc: Andrew Fish <afish@apple.com>
Cc: Ray Ni <ray.ni@intel.com>
Signed-off-by: Guomin Jiang <guomin.jiang@intel.com>